### PR TITLE
Update deploy process to gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is suggested that you use [nvm](https://github.com/creationix/nvm#installatio
   ```
 
 2. Install JavaScript developer tools.
-   
+
    ```bash
    yarn
    ```
@@ -27,7 +27,7 @@ It is suggested that you use [nvm](https://github.com/creationix/nvm#installatio
 3. In Typekit, add the font [Franklin Gothic URW](https://typekit.com/fonts/franklin-gothic-urw) to your kit, then add the Typekit Kit ID to `gulp-tasks/html.js`
 
 4. Serve up the site locally at http://localhost:3000
-   
+
    ```bash
    gulp serve
    ```
@@ -47,3 +47,9 @@ To add additional vendor scripts, such as jQuery UI, you'll do that by updating 
 ### Eyeglass, known "error"
 
 When running `gulp styles` you can disregard the following error, `The following modules are incompatible with eyeglass 1.1.2: bootstrap-sass needed eyeglass ^0.7.1`. `bootstrap-sass` is actually compatible it just throws an error.
+
+## Deploying the site to http://emulsify.info/.
+
+The files for http://emulsify.info are hosted in the `gh-pages` branch of this repo.
+
+To deploy a new version of the site use the command `gulp deploy`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the source files used for the design of the Emulsify la
 
 Install the following dependencies:
 
-- [Node.js](https://nodejs.org/)
+- [Node 7+](https://nodejs.org/)
 
 It is suggested that you use [nvm](https://github.com/creationix/nvm#installation) to [install and use](https://github.com/creationix/nvm#usage) node.js 6.x or 7.x.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,11 +10,17 @@
   const gulpSequence = require('gulp-sequence')
   require('require-dir')('./gulp-tasks')
 
-  var ghPages = require('gulp-gh-pages')
+  var ghPages = require('gh-pages')
 
-  gulp.task('deploy', ['build'], function () {
-    return gulp.src('./dist/**/*')
-      .pipe(ghPages())
+  gulp.task('deploy', ['build'], () => {
+    // Publish the build directory to github pages.
+    ghPages.publish(config.paths.dist, (err) => {
+      if (err === undefined) {
+        console.log('Successfully deployed!')
+      } else {
+        console.log(err)
+      }
+    })
   })
 
   /**
@@ -28,7 +34,15 @@
   /**
    * Build task.
    */
-  gulp.task('build', gulpSequence(['clean'], ['imagemin', 'styles', 'scripts', 'html', 'move-fonts', 'move-morgue'], ['lint']))
+  gulp.task('build', gulpSequence(['clean'], ['imagemin', 'styles', 'scripts', 'html', 'move-fonts', 'move-morgue', 'cname'], ['lint']))
+
+  /**
+   * Move CNAME file to /dist
+   */
+  gulp.task('cname', () => {
+    gulp.src('CNAME', { base: './' })
+      .pipe(gulp.dest(config.paths.dist))
+  })
 
   /**
    * Task for running browserSync.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "gulpfile.js",
   "dependencies": {
-    "breakpoint-sass": "^2.7.1"
+    "breakpoint-sass": "^2.7.1",
+    "gh-pages": "^1.1.0"
   },
   "devDependencies": {
     "browser-sync": "^2.17.0",
@@ -21,7 +22,6 @@
     "gulp-concat": "^2.6.0",
     "gulp-eslint": "^3.0.1",
     "gulp-flatten": "^0.3.1",
-    "gulp-gh-pages": "^0.5.4",
     "gulp-help": "^1.6.1",
     "gulp-imagemin": "^3.0.3",
     "gulp-sass": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "type": "git",
     "url": "git+https://github.com/amazingrando/foo.git"
   },
-  "engines": {
-    "node": "^7"
-  },
   "author": "Randy Oest, Amazing Rando Design",
   "license": "ISC",
   "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,12 @@ async@1.5.2, async@^1.3.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
+async@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
+  dependencies:
+    lodash "^4.14.0"
+
 async@^0.9.0, async@~0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
@@ -276,6 +282,10 @@ base64-js@^1.0.2:
 base64id@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-0.1.0.tgz#02ce0fdeee0cef4f40080e1e73e834f0b1bfce3f"
+
+base64url@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
 
 batch@0.5.3:
   version "0.5.3"
@@ -732,6 +742,10 @@ combined-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-0.0.7.tgz#0137e657baa5a7541c57ac37ac5fc07d73b4dc1f"
   dependencies:
     delayed-stream "0.0.5"
+
+commander@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 commander@2.8.x, commander@~2.8.1:
   version "2.8.1"
@@ -1335,10 +1349,6 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
-es6-promise@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-2.3.0.tgz#96edb9f2fdb01995822b263dd8aadab6748181bc"
-
 es6-set@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.4.tgz#9516b6761c2964b92ff479456233a247dc707ce8"
@@ -1866,6 +1876,14 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1975,6 +1993,18 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gh-pages@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-1.1.0.tgz#738134d8e35e5323b39892cda28b8904e85f24b2"
+  dependencies:
+    async "2.6.0"
+    base64url "^2.0.0"
+    commander "2.11.0"
+    fs-extra "^4.0.2"
+    globby "^6.1.0"
+    graceful-fs "4.1.11"
+    rimraf "^2.6.2"
+
 gifsicle@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/gifsicle/-/gifsicle-3.0.4.tgz#f45cb5ed10165b665dc929e0e9328b6c821dfa3b"
@@ -1982,12 +2012,6 @@ gifsicle@^3.0.0:
     bin-build "^2.0.0"
     bin-wrapper "^3.0.0"
     logalot "^2.0.0"
-
-gift@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/gift/-/gift-0.6.1.tgz#c1698e6b6887164ed978a01095423cff65b8e79f"
-  dependencies:
-    underscore "1.x.x"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2114,6 +2138,16 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 globule@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/globule/-/globule-1.1.0.tgz#c49352e4dc183d85893ee825385eb994bb6df45f"
@@ -2162,7 +2196,7 @@ got@^5.0.0:
     unzip-response "^1.0.2"
     url-parse-lax "^1.0.0"
 
-graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@4.1.11, graceful-fs@4.X, graceful-fs@^4.0.0, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2239,17 +2273,6 @@ gulp-flatten@^0.3.1:
   dependencies:
     gulp-util "^3.0.7"
     through2 "^2.0.0"
-
-gulp-gh-pages@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/gulp-gh-pages/-/gulp-gh-pages-0.5.4.tgz#a6732ca475ab9b5a53253c1c24734c40c21b6546"
-  dependencies:
-    gift "^0.6.1"
-    gulp-util "^3.0.7"
-    readable-stream "^2.0.2"
-    rimraf "^2.4.3"
-    vinyl-fs "^2.2.1"
-    wrap-promise "^1.0.1"
 
 gulp-help@^1.6.1:
   version "1.6.1"
@@ -2988,6 +3011,12 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3344,6 +3373,10 @@ lodash@^3.10.1:
 lodash@^4.0.0, lodash@^4.16.3, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.14.0:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 lodash@~1.0.1:
   version "1.0.2"
@@ -4481,7 +4514,7 @@ rimraf@2, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@~2.5.1, rimraf@~2.
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.4.3:
+rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -5269,10 +5302,6 @@ underscore@1.7.x:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
-underscore@1.x.x:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
-
 unique-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-stream/-/unique-stream-1.0.0.tgz#d59a4a75427447d9aa6c91e70263f8d26a4b104b"
@@ -5283,6 +5312,10 @@ unique-stream@^2.0.2:
   dependencies:
     json-stable-stringify "^1.0.0"
     through2-filter "^2.0.0"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -5390,7 +5423,7 @@ vinyl-fs@^0.3.0:
     through2 "^0.6.1"
     vinyl "^0.4.0"
 
-vinyl-fs@^2.2.0, vinyl-fs@^2.2.1:
+vinyl-fs@^2.2.0:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-2.4.4.tgz#be6ff3270cb55dfd7d3063640de81f25d7532239"
   dependencies:
@@ -5600,12 +5633,6 @@ wrap-fn@^0.1.0:
   resolved "https://registry.yarnpkg.com/wrap-fn/-/wrap-fn-0.1.5.tgz#f21b6e41016ff4a7e31720dbc63a09016bdf9845"
   dependencies:
     co "3.1.0"
-
-wrap-promise@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wrap-promise/-/wrap-promise-1.0.1.tgz#b019f4236ccbf1fb560921b4b4870b7bda2f5255"
-  dependencies:
-    es6-promise "^2.3.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This PR moves the project from the broken `gulp-gh-pages` to the working `gh-pages` package.

## How to review
- Download this branch
- [x] Run `yarn` to get update packages
- [x] Run `gulp deploy` to confirm that changes are pushed to the `gh-pages` branch.